### PR TITLE
Fix Issue #2: cron.sh file has wrong binary name.

### DIFF
--- a/source/cron.sh
+++ b/source/cron.sh
@@ -10,7 +10,7 @@ if [ "$TIDEWAY" == "" ]; then
 fi
 . $TIDEWAY/tw_setup
 
-echo "$cron $root/get" >> traversys_getCert.cron
+echo "$cron $root/getcert" >> traversys_getCert.cron
 mv traversys_getCert.cron /usr/tideway/etc/cron/
 tw_cron_update
 echo ""


### PR DESCRIPTION
## Description
Fixed the misspelled binary name from
`echo "$cron $root/get" >> traversys_getCert.cron`
to 
`echo "$cron $root/getcert" >> traversys_getCert.cron`
as requested by the maintainer

Fixes #2 